### PR TITLE
Update .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://npm.icapps.com
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
npm.icapps.com is going to be deleted, better to use https://registry.npmjs.org/